### PR TITLE
OpenCV as standalone dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,9 +12,10 @@ find_package(catkin REQUIRED COMPONENTS
   sensor_msgs
   cv_bridge
   image_transport
-  OpenCV
   rosbag
 )
+
+find_package( OpenCV REQUIRED )
 
 include_directories(
 	include


### PR DESCRIPTION
Set OpenCV as standalone dependency to fix compilation error: `Could not find a package configuration file provided by "OpenCV"`.
See also: http://answers.ros.org/question/123241/could-not-find-a-configuration-file-for-package-opencv/?answer=123286#post-id-123286

